### PR TITLE
Fix Build (Xcode 11, Swift 5.1)

### DIFF
--- a/DDC/DDC.swift
+++ b/DDC/DDC.swift
@@ -273,7 +273,7 @@ public class DDC {
     }
   }
 
-  public func sendMessage(_ message: [UInt8], replyData: inout [UInt8] = [], minReplyDelay: UInt64? = nil, errorRecoveryWaitTime: UInt32? = nil) -> IOI2CRequest? {
+  public func sendMessage(_ message: [UInt8], replyData: inout [UInt8], minReplyDelay: UInt64? = nil, errorRecoveryWaitTime: UInt32? = nil) -> IOI2CRequest? {
     var data: [UInt8] = [UInt8(0x51), UInt8(0x80 + message.count)] + message + [UInt8(0x6E)]
 
     for i in 0..<(data.count - 1) {


### PR DESCRIPTION
I've removed the default value for the `inout` parameter in the `sendMessage` method. I could not build the project without this change.