### PR TITLE
Add support for Swift Package Manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,3 @@
 # Swift Package Manager
 .build
 .swiftpm
-

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,7 @@
 /Carthage
 *.xcuserdatad
+
+# Swift Package Manager
+.build
+.swiftpm
+

--- a/DDC.xcodeproj/project.pbxproj
+++ b/DDC.xcodeproj/project.pbxproj
@@ -12,7 +12,6 @@
 		2875061720786F5A00F8D7BD /* Nimble.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 284EB28320782DE6002A3BA6 /* Nimble.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		2875061820786F5A00F8D7BD /* Quick.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 284EB28420782DE6002A3BA6 /* Quick.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		2899042822601241004CBB6F /* DDCSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2899042722601241004CBB6F /* DDCSpec.swift */; };
-		2899042B226018D4004CBB6F /* DDC.h in Headers */ = {isa = PBXBuildFile; fileRef = 2899042A226018D4004CBB6F /* DDC.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		OBJ_59 /* DDC.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_9 /* DDC.swift */; };
 		OBJ_60 /* EDID.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_10 /* EDID.swift */; };
 /* End PBXBuildFile section */
@@ -48,7 +47,6 @@
 		284EB28320782DE6002A3BA6 /* Nimble.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Nimble.framework; path = Carthage/Build/Mac/Nimble.framework; sourceTree = "<group>"; };
 		284EB28420782DE6002A3BA6 /* Quick.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Quick.framework; path = Carthage/Build/Mac/Quick.framework; sourceTree = "<group>"; };
 		2899042722601241004CBB6F /* DDCSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DDCSpec.swift; sourceTree = "<group>"; };
-		2899042A226018D4004CBB6F /* DDC.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DDC.h; sourceTree = "<group>"; };
 		28990432226025F6004CBB6F /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		"DDC::DDC::Product" /* DDC.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = DDC.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		OBJ_10 /* EDID.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EDID.swift; sourceTree = "<group>"; };
@@ -115,7 +113,6 @@
 		OBJ_8 /* DDC */ = {
 			isa = PBXGroup;
 			children = (
-				2899042A226018D4004CBB6F /* DDC.h */,
 				OBJ_9 /* DDC.swift */,
 				OBJ_10 /* EDID.swift */,
 				28990432226025F6004CBB6F /* Info.plist */,
@@ -130,7 +127,6 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				2899042B226018D4004CBB6F /* DDC.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -484,7 +480,6 @@
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = YES;
 				SUPPORTED_PLATFORMS = macosx;
-				SWIFT_OBJC_BRIDGING_HEADER = DDC/DDC.h;
 				SWIFT_VERSION = 5.0;
 				TARGET_NAME = DDC;
 			};
@@ -513,7 +508,6 @@
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = YES;
 				SUPPORTED_PLATFORMS = macosx;
-				SWIFT_OBJC_BRIDGING_HEADER = DDC/DDC.h;
 				SWIFT_VERSION = 5.0;
 				TARGET_NAME = DDC;
 			};

--- a/DDC/DDC.h
+++ b/DDC/DDC.h
@@ -1,3 +1,0 @@
-#pragma once
-
-#include <IOKit/i2c/IOI2CInterface.h>

--- a/DDC/DDC.swift
+++ b/DDC/DDC.swift
@@ -1,6 +1,6 @@
 import Cocoa
 import Foundation
-import IOKit
+import IOKit.i2c
 import os.log
 
 public class DDC {

--- a/Package.swift
+++ b/Package.swift
@@ -1,28 +1,20 @@
 // swift-tools-version:5.0
-// The swift-tools-version declares the minimum version of Swift required to build this package.
 import PackageDescription
 
 let package = Package(
-    name: "DDC.swift",
-    platforms: [
-        .macOS(.v10_12)
-    ],
-    products: [
-        // Products define the executables and libraries produced by a package, and make them visible to other packages.
-        .library(
-            name: "DDC",
-            targets: ["DDC"]),
-    ],
-    dependencies: [
-        // Dependencies declare other packages that this package depends on.
-        // .package(url: /* package url */, from: "1.0.0"),
-    ],
-    targets: [
-        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
-        // Targets can depend on other targets in this package, and on products in packages which this package depends on.
-        .target(
-            name: "DDC",
-            dependencies: [],
-            path: "DDC"),
-    ]
+  name: "DDC.swift",
+  platforms: [
+    .macOS(.v10_12)
+  ],
+  products: [
+    .library(
+      name: "DDC",
+      targets: ["DDC"]),
+  ],
+  targets: [
+    .target(
+      name: "DDC",
+      dependencies: [],
+      path: "DDC"),
+  ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,28 @@
+// swift-tools-version:5.0
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+import PackageDescription
+
+let package = Package(
+    name: "DDC.swift",
+    platforms: [
+        .macOS(.v10_12)
+    ],
+    products: [
+        // Products define the executables and libraries produced by a package, and make them visible to other packages.
+        .library(
+            name: "DDC",
+            targets: ["DDC"]),
+    ],
+    dependencies: [
+        // Dependencies declare other packages that this package depends on.
+        // .package(url: /* package url */, from: "1.0.0"),
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
+        // Targets can depend on other targets in this package, and on products in packages which this package depends on.
+        .target(
+            name: "DDC",
+            dependencies: [],
+            path: "DDC"),
+    ]
+)


### PR DESCRIPTION
This adds the ability to add this project as a dependency via Swift Package Manager. In order to do this I needed to import `IOKit.i2c` instead of `IOKit` (I've not been able to figure out _why_ yet, but it works..), but this allowed me to drop the bridging header so I did that too 🙂 