### PR TITLE
Fix service port detection for identical monitors 

### DIFF
--- a/DDC/DDC.swift
+++ b/DDC/DDC.swift
@@ -545,7 +545,21 @@ public class DDC {
                portSerialNumber, displaySerialNumber)
         continue
       }
-
+      
+      if let displayLocation = dict[kIODisplayLocationKey] as? NSString {
+        // the unit number is the number right after the last "@" sign in the display location
+        if let regex = try? NSRegularExpression(pattern: "@([0-9]+)[^@]+$", options: []) {
+          if let match = regex.firstMatch(in: displayLocation as String, options: [],
+                  range: NSRange(location: 0, length: displayLocation.length)) {
+            let unitNumber = UInt32(displayLocation.substring(with: match.range(at: 1)))
+        
+            guard unitNumber == CGDisplayUnitNumber(displayId) else {
+              continue
+            }
+          }
+        }
+      }
+  
       var name: io_name_t?
       let size = MemoryLayout.size(ofValue: name)
       if let framebufferName = (withUnsafeMutablePointer(to: &name) {

--- a/DDC/DDC.swift
+++ b/DDC/DDC.swift
@@ -556,7 +556,7 @@ public class DDC {
       
       if detectUnitNumber, let displayLocation = dict[kIODisplayLocationKey] as? NSString {
         // the unit number is the number right after the last "@" sign in the display location
-        let regex = (try? NSRegularExpression(pattern: "@([0-9]+)[^@]+$", options: []))!
+        let regex = try! NSRegularExpression(pattern: "@([0-9]+)[^@]+$", options: [])
         if let match = regex.firstMatch(in: displayLocation as String, options: [],
                 range: NSRange(location: 0, length: displayLocation.length)) {
           let unitNumber = UInt32(displayLocation.substring(with: match.range(at: 1)))


### PR DESCRIPTION
Main goal of this PR is to fix service port detection of multiple identical monitors connected to a machine. 

This PR is an adaptation of [this](https://github.com/fnesveda/ExternalDisplayBrightness/commit/e20bfb801cf747bea28884a92559f817a27a1aff) fix in a similar library. It has a regex that works with some models only, for instance Benq monitors. The fix has a fallback to an original service port detection. 

 [Here](https://github.com/MonitorControl/MonitorControl/issues/49) is a long discussion of the issue.