### PR TITLE
Fix build error produced by SwiftLint for 'force_try'

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -6,8 +6,6 @@ disabled_rules:
   - large_tuple
   - nesting
   - cyclomatic_complexity
-force_try:
-  severity: warning
 excluded:
   - Carthage
 type_body_length: 500

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -6,6 +6,8 @@ disabled_rules:
   - large_tuple
   - nesting
   - cyclomatic_complexity
+force_try:
+  severity: warning
 excluded:
   - Carthage
 type_body_length: 500

--- a/DDC/DDC.swift
+++ b/DDC/DDC.swift
@@ -556,6 +556,7 @@ public class DDC {
       
       if detectUnitNumber, let displayLocation = dict[kIODisplayLocationKey] as? NSString {
         // the unit number is the number right after the last "@" sign in the display location
+        // swiftlint:disable:next force_try
         let regex = try! NSRegularExpression(pattern: "@([0-9]+)[^@]+$", options: [])
         if let match = regex.firstMatch(in: displayLocation as String, options: [],
                 range: NSRange(location: 0, length: displayLocation.length)) {


### PR DESCRIPTION
## Notes
- **This pull request resolves a build error produced by `SwiftLint`.**
- ***Warning*** is now produced instead of ***Error*** by `SwiftLint`.

### Before
<img width="1269" alt="image" src="https://user-images.githubusercontent.com/12025248/114264514-5fb40480-9a26-11eb-95cb-f081c7bdb0cb.png">

### After
<img width="1269" alt="image" src="https://user-images.githubusercontent.com/12025248/114264913-b4587f00-9a28-11eb-8351-1fad3dc5f7d5.png">
